### PR TITLE
Use ReadLineAsync instead of ReadLine

### DIFF
--- a/Mastonet/TimelineStreaming.cs
+++ b/Mastonet/TimelineStreaming.cs
@@ -40,7 +40,7 @@ namespace Mastonet
 
             while (client != null)
             {
-                var line = reader.ReadLine();
+                var line = await reader.ReadLineAsync();
 
 
                 if (string.IsNullOrEmpty(line) || line.StartsWith(":"))


### PR DESCRIPTION
Use "ReadLineAsync" instead of "ReadLine" to prevent thread blocking.