### PR TITLE
Make streaming hand-able errors

### DIFF
--- a/Mastonet/StreamEventArgs.cs
+++ b/Mastonet/StreamEventArgs.cs
@@ -19,9 +19,4 @@ namespace Mastonet
     {
         public int StatusId { get; set; }
     }
-
-    public class StreamErrorEventArgs : EventArgs
-    {
-        public Exception Exception { get; set; }
-    }
 }

--- a/Mastonet/StreamEventArgs.cs
+++ b/Mastonet/StreamEventArgs.cs
@@ -19,4 +19,9 @@ namespace Mastonet
     {
         public int StatusId { get; set; }
     }
+
+    public class StreamErrorEventArgs : EventArgs
+    {
+        public Exception Exception { get; set; }
+    }
 }

--- a/Mastonet/TimelineStreaming.cs
+++ b/Mastonet/TimelineStreaming.cs
@@ -19,7 +19,6 @@ namespace Mastonet
         public event EventHandler<StreamUpdateEventArgs> OnUpdate;
         public event EventHandler<StreamNotificationEventArgs> OnNotification;
         public event EventHandler<StreamDeleteEventArgs> OnDelete;
-        public event EventHandler<StreamErrorEventArgs> OnError;
 
         internal TimelineStreaming(string url, string accessToken)
         {
@@ -30,58 +29,51 @@ namespace Mastonet
 
         public async Task Start()
         {
-            try
-            {
-                client = new HttpClient();
-                client.DefaultRequestHeaders.Add("Authorization", "Bearer " + accessToken);
+            client = new HttpClient();
+            client.DefaultRequestHeaders.Add("Authorization", "Bearer " + accessToken);
 
-                var stream = await client.GetStreamAsync(url);
+            var stream = await client.GetStreamAsync(url);
 
-                var reader = new StreamReader(stream);
+            var reader = new StreamReader(stream);
                 
-                string eventName = null;
-                string data = null;
+            string eventName = null;
+            string data = null;
 
-                while (client != null)
+            while (client != null)
+            {
+                var line = await reader.ReadLineAsync();
+
+
+                if (string.IsNullOrEmpty(line) || line.StartsWith(":"))
                 {
-                    var line = await reader.ReadLineAsync();
+                    eventName = data = null;
+                    continue;
+                }
 
+                if (line.StartsWith("event: "))
+                {
+                    eventName = line.Substring("event: ".Length).Trim();
+                }
+                else if (line.StartsWith("data: "))
+                {
+                    data = line.Substring("data: ".Length);
 
-                    if (string.IsNullOrEmpty(line) || line.StartsWith(":"))
+                    switch (eventName)
                     {
-                        eventName = data = null;
-                        continue;
-                    }
-
-                    if (line.StartsWith("event: "))
-                    {
-                        eventName = line.Substring("event: ".Length).Trim();
-                    }
-                    else if (line.StartsWith("data: "))
-                    {
-                        data = line.Substring("data: ".Length);
-
-                        switch (eventName)
-                        {
-                            case "update":
-                                var status = JsonConvert.DeserializeObject<Status>(data);
-                                OnUpdate?.Invoke(this, new StreamUpdateEventArgs() { Status = status });
-                                break;
-                            case "notification":
-                                var notification = JsonConvert.DeserializeObject<Notification>(data);
-                                OnNotification?.Invoke(this, new StreamNotificationEventArgs() { Notification = notification });
-                                break;
-                            case "delete":
-                                var statusId = int.Parse(data);
-                                OnDelete?.Invoke(this, new StreamDeleteEventArgs() { StatusId = statusId });
-                                break;
-                        }
+                        case "update":
+                            var status = JsonConvert.DeserializeObject<Status>(data);
+                            OnUpdate?.Invoke(this, new StreamUpdateEventArgs() { Status = status });
+                            break;
+                        case "notification":
+                            var notification = JsonConvert.DeserializeObject<Notification>(data);
+                            OnNotification?.Invoke(this, new StreamNotificationEventArgs() { Notification = notification });
+                            break;
+                        case "delete":
+                            var statusId = int.Parse(data);
+                            OnDelete?.Invoke(this, new StreamDeleteEventArgs() { StatusId = statusId });
+                            break;
                     }
                 }
-            }
-            catch (Exception ex)
-            {
-                OnError?.Invoke(this, new StreamErrorEventArgs() { Exception = ex });
             }
             this.Stop();
         }


### PR DESCRIPTION
There are some cases `TimelineStreaming.Start()` throws `IOException` especially timeline updated rapidly.
The exception looks from `ReadLineAsync` method.
When the error occured, the streaming is stopped.
And, we can't handle because `Start` method is asynchronous.

So, I made `Start` method wait-able.
It's simple, `void Start()` to `Task Start()`.
Only this, we can use `await` and write following:

~~~~
while (true)
{
    try
    {
        await streaming.Start();
    }
    catch (Exception e)
    {
        // print exception detail.
    }
}
~~~~

And a little change...
- Adding null-check in `Stop` method