### PR TITLE
Fix json parse error

### DIFF
--- a/Mastonet/BaseHttpClient.cs
+++ b/Mastonet/BaseHttpClient.cs
@@ -95,12 +95,14 @@ namespace Mastonet
 
         private T TryDeserialize<T>(string json)
         {
-            //TODO handle error gracefully
-            //var error = JsonConvert.DeserializeObject<Error>(json);
-            //if (!string.IsNullOrEmpty(error.Description))
-            //{
-            //    throw new ServerErrorException(error);
-            //}
+            if (json[0] == '{')
+            {
+                var error = JsonConvert.DeserializeObject<Error>(json);
+                if (!string.IsNullOrEmpty(error.Description))
+                {
+                    throw new ServerErrorException(error);
+                }
+            }
 
             return JsonConvert.DeserializeObject<T>(json);
         }


### PR DESCRIPTION
This code fixes #2 issue.

Json array starts with `[`. But, json object starts with `{`.
When try to parse json array as a object, Newtonsoft.Json throws an exception.
So, I check the first char equals `{` before parse `Error` object.

https://github.com/tootsuite/documentation/blob/master/Using-the-API/API.md
There seem no api returns multiple `Error` as array, in other words, no `Error` array starts with `[` .