### PR TITLE
Changed delete events to use long instead of int

### DIFF
--- a/Mastonet/StreamEventArgs.cs
+++ b/Mastonet/StreamEventArgs.cs
@@ -17,6 +17,6 @@ namespace Mastonet
 
     public class StreamDeleteEventArgs : EventArgs
     {
-        public int StatusId { get; set; }
+        public long StatusId { get; set; }
     }
 }

--- a/Mastonet/TimelineStreaming.cs
+++ b/Mastonet/TimelineStreaming.cs
@@ -69,7 +69,7 @@ namespace Mastonet
                             OnNotification?.Invoke(this, new StreamNotificationEventArgs() { Notification = notification });
                             break;
                         case "delete":
-                            var statusId = int.Parse(data);
+                            var statusId = long.Parse(data);
                             OnDelete?.Invoke(this, new StreamDeleteEventArgs() { StatusId = statusId });
                             break;
                     }


### PR DESCRIPTION
Streaming the public timeline tended to break very quickly before this quick fix. It's worth noting that this would probably be a breaking change for anyone handling delete events already.