### PR TITLE
Added reply count

### DIFF
--- a/Mastonet/Entities/Status.cs
+++ b/Mastonet/Entities/Status.cs
@@ -62,6 +62,12 @@ namespace Mastonet.Entities
         public DateTime CreatedAt { get; set; }
 
         /// <summary>
+        /// The number of replies for the status
+        /// </summary>
+        [JsonProperty("replies_count")]
+        public int RepliesCount { get; set; }
+
+        /// <summary>
         /// The number of reblogs for the status
         /// </summary>
         [JsonProperty("reblogs_count")]


### PR DESCRIPTION
Grabs the number of replies for a given status, as shown in the [Mastodon API docs](https://github.com/tootsuite/documentation/blob/master/Using-the-API/API.md#status).