### PR TITLE
Added emoji

### DIFF
--- a/Mastonet/Entities/Emoji.cs
+++ b/Mastonet/Entities/Emoji.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Newtonsoft.Json;
+
+namespace Mastonet.Entities
+{
+    public class Emoji
+    {
+        /// <summary>
+        /// The shortcode of the emoji
+        /// </summary>
+        [JsonProperty("shortcode")]
+        public string Shortcode { get; set; }
+
+        /// <summary>
+        /// URL to the emoji static image
+        /// </summary>
+        [JsonProperty("static_url")]
+        public string StaticUrl { get; set; }
+
+        /// <summary>
+        /// URL to the emoji image
+        /// </summary>
+        [JsonProperty("url")]
+        public string Url { get; set; }
+
+        /// <summary>
+        /// Boolean that indicates if the emoji is visible in picker
+        /// </summary>
+        [JsonProperty("visible_in_picker")]
+        public bool VisibleInPicker { get; set; }
+    }
+}

--- a/Mastonet/Entities/Status.cs
+++ b/Mastonet/Entities/Status.cs
@@ -110,6 +110,12 @@ namespace Mastonet.Entities
         public Visibility Visibility { get; set; }
 
         /// <summary>
+        /// An array of Emojis
+        /// </summary>
+        [JsonProperty("emojis")]
+        public IEnumerable<Emoji> Emojis { get; set; }
+
+        /// <summary>
         /// An array of Attachments
         /// </summary>
         [JsonProperty("media_attachments")]


### PR DESCRIPTION
Grabs the custom emoji used for a given status, as shown in the [Mastodon API docs](https://github.com/tootsuite/documentation/blob/master/Using-the-API/API.md#status). ([Emoji entity](https://github.com/tootsuite/documentation/blob/master/Using-the-API/API.md#emoji))