### PR TITLE
Update entities to match the latest API version (2.7.4) except for Push API

### DIFF
--- a/Mastonet/Entities/Account.cs
+++ b/Mastonet/Entities/Account.cs
@@ -1,5 +1,6 @@
 ﻿using Newtonsoft.Json;
 using System;
+using System.Collections.Generic;
 
 namespace Mastonet.Entities
 {
@@ -94,5 +95,83 @@ namespace Mastonet.Entities
         /// </summary>
         [JsonProperty("header_static")]
         public string StaticHeaderUrl { get; set; }
+
+        /// <summary>
+        /// Emojis used in the account info
+        /// </summary>
+        [JsonProperty("emojis")]
+        public IEnumerable<Emoji> Emojis { get; set; }
+
+        /// <summary>
+        /// If moved, the new account for the account
+        /// </summary>
+        [JsonProperty("moved")]
+        public Account Moved { get; set; }
+
+        /// <summary>
+        /// The custom fields of the account
+        /// </summary>
+        [JsonProperty("Fields")]
+        public IEnumerable<Field> Fields { get; set; }
+
+        /// <summary>
+        /// Whether the account is a bot
+        /// </summary>
+        [JsonProperty("bot")]
+        public bool? Bot { get; set; }
+    }
+
+    public class Field
+    {
+        /// <summary>
+        /// The name of the field
+        /// </summary>
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// The value of the field (HTML)
+        /// </summary>
+        [JsonProperty("value")]
+        public string Value { get; set; }
+
+        /// <summary>
+        /// The datetime when the account is verified if the field value is a link
+        /// </summary>
+        [JsonProperty("verified_at")]
+        public DateTime? VerifiedAt { get; set; }
+    }
+    
+    public class Source
+    {
+        /// <summary>
+        /// The default visibility for the account
+        /// </summary>
+        [JsonProperty("privacy")]
+        public Visibility Privacy { get; set; }
+
+        /// <summary>
+        /// The default media sensitiveness setting for the account
+        /// </summary>
+        [JsonProperty("sensitive")]
+        public bool? Sensitive { get; set; }
+
+        /// <summary>
+        /// The language setting for the account (ISO6391)
+        /// </summary>
+        [JsonProperty("language")]
+        public string Language { get; set; }
+
+        /// <summary>
+        /// Biography of the user (in plain text)
+        /// </summary>
+        [JsonProperty("note")]
+        public string Note { get; set; }
+
+        /// <summary>
+        /// The custom fields of the account (in plain text)
+        /// </summary>
+        [JsonProperty("sensitive")]
+        public IEnumerable<Field> Fields { get; set; }
     }
 }

--- a/Mastonet/Entities/Attachment.cs
+++ b/Mastonet/Entities/Attachment.cs
@@ -1,4 +1,5 @@
 ﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -43,6 +44,16 @@ namespace Mastonet.Entities
         [JsonProperty("text_url")]
         public string TextUrl { get; set; }
 
+        ///<summary>
+        /// Metadata of the attachment
+        ///</summary>
+        [JsonProperty("meta")]
+        public JObject Meta { get; set; }
 
+        /// <summary>
+        /// Description of the attachment
+        /// </summary>
+        [JsonProperty("description")]
+        public string Description { get; set; }
     }
 }

--- a/Mastonet/Entities/Filter.cs
+++ b/Mastonet/Entities/Filter.cs
@@ -1,0 +1,46 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Mastonet.Entities
+{
+    public class Filter
+    {
+        /// <summary>
+        /// ID of the filter
+        /// </summary>
+        [JsonProperty("id")]
+        public long Id { get; set; }
+
+        /// <summary>
+        /// Keyword or phrase to filter
+        /// </summary>
+        [JsonProperty("phrase")]
+        public string Phrase { get; set; }
+
+        /// <summary>
+        /// Contexts to apply the filter
+        /// </summary>
+        [JsonProperty("context")]
+        public IEnumerable<string> Context { get; set; }
+
+        /// <summary>
+        /// DateTime when the filter expires if set
+        /// </summary>
+        [JsonProperty("expires_at")]
+        public DateTime? ExpiresAt { get; set; }
+
+        /// <summary>
+        /// Whether the filter is irreversible
+        /// </summary>
+        [JsonProperty("irrevsersible")]
+        public bool Irreversible { get; set; }
+
+        /// <summary>
+        /// Whether to consider word boundaries when matching
+        /// </summary>
+        [JsonProperty("whole_word")]
+        public bool WholeWord { get; set; }
+    }
+}

--- a/Mastonet/Entities/Instance.cs
+++ b/Mastonet/Entities/Instance.cs
@@ -30,5 +30,71 @@ namespace Mastonet.Entities
         /// </summary>
         [JsonProperty("email")]
         public string Email { get; set; }
+
+        /// <summary>
+        /// The Mastodon version of the instance
+        /// </summary>
+        [JsonProperty("version")]
+        public string Version { get; set; }
+
+        /// <summary>
+        /// URI for the thumbnail of the hero image
+        /// </summary>
+        [JsonProperty("thumbnail")]
+        public string Thumbnail { get; set; }
+
+        /// <summary>
+        /// URLs related to the instance
+        /// </summary>
+        [JsonProperty("urls")]
+        public URLs Urls { get; set; }
+
+        /// <summary>
+        /// The instance's stats
+        /// </summary>
+        [JsonProperty("stats")]
+        public Stats Stats { get; set; }
+
+        /// <summary>
+        /// Array that consists of the instance's default locale
+        /// </summary>
+        [JsonProperty("languages")]
+        public IEnumerable<string> Languages { get; set; }
+
+        /// <summary>
+        /// The instance's admin account
+        /// </summary>
+        [JsonProperty("contact_account")]
+        public Account ContactAccount { get; set; }
+    }
+
+    public class URLs
+    {
+        /// <summary>
+        /// Websocket base URL for streaming API
+        /// </summary>
+        [JsonProperty("streaming_api")]
+        public string StreamingAPI { get; set; }
+    }
+
+    public class Stats
+    {
+        /// <summary>
+        /// Number of users that belongs to the instance
+        /// </summary>
+        [JsonProperty("user_count")]
+        public int UserCount { get; set; }
+
+        /// <summary>
+        /// Number of statuses that belongs to the instance
+        /// </summary>
+        [JsonProperty("status_count")]
+        public int StatusCount { get; set; }
+
+        /// <summary>
+        /// Number of remote instances known to the instance
+        /// </summary>
+        [JsonProperty("domain_count")]
+        public int DomainCount { get; set; }
     }
 }

--- a/Mastonet/Entities/List.cs
+++ b/Mastonet/Entities/List.cs
@@ -1,0 +1,22 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Mastonet.Entities
+{
+    public class List
+    {
+        /// <summary>
+        /// ID of the list
+        /// </summary>
+        [JsonProperty("id")]
+        public long Id { get; set; }
+
+        /// <summary>
+        /// Title of the list
+        /// </summary>
+        [JsonProperty("title")]
+        public string Title { get; set; }
+    }
+}

--- a/Mastonet/Entities/ScheduledStatus.cs
+++ b/Mastonet/Entities/ScheduledStatus.cs
@@ -1,0 +1,85 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Mastonet.Entities
+{
+    public class ScheduledStatus
+    {
+        /// <summary>
+        /// The scheduled status's ID
+        /// </summary>
+        [JsonProperty("id")]
+        public long Id { get; set; }
+
+        /// <summary>
+        /// DateTime to publish the scheduled status
+        /// </summary>
+        [JsonProperty("scheduled_at")]
+        public DateTime ScheduledAt { get; set; }
+
+        /// <summary>
+        /// Parameters of the scheduled status
+        /// </summary>
+        [JsonProperty("params")]
+        public StatusParams Params { get; set; }
+
+        /// <summary>
+        /// Media attached to the scheduled status
+        /// </summary>
+        [JsonProperty("media_attachments")]
+        public IEnumerable<Attachment> MediaAttachments { get; set; }
+    }
+
+    public class StatusParams
+    {
+        /// <summary>
+        /// Content of the status in plain text
+        /// </summary>
+        [JsonProperty("text")]
+        public string Text { get; set; }
+
+        /// <summary>
+        /// null or the ID of the status it replies to
+        /// </summary>
+        [JsonProperty("in_reply_to_id")]
+        public string InReplyToId { get; set; }
+
+        /// <summary>
+        /// IDs of the attachments
+        /// </summary>
+        [JsonProperty("media_ids")]
+        public IEnumerable<long> MediaIds { get; set; }
+
+        /// <summary>
+        /// Whether to mark the attachment as sensitive, or null 
+        /// </summary>
+        [JsonProperty("sensitive")]
+        public bool? Sensitive { get; set; }
+
+        /// <summary>
+        /// Spoiler text if any
+        /// </summary>
+        [JsonProperty("spoiler_text")]
+        public string SpoilerText { get; set; }
+
+        /// <summary>
+        /// Visibility of the scheduled status
+        /// </summary>
+        [JsonProperty("visibility")]
+        public Visibility Visibility { get; set; }
+
+        /// <summary>
+        /// DateTime to publish the scheduled status
+        /// </summary>
+        [JsonProperty("scheduled_at")]
+        public DateTime? ScheduledAt { get; set; }
+
+        /// <summary>
+        /// Application ID that created the scheduled status
+        /// </summary>
+        [JsonProperty("application_id")]
+        public long ApplicationId { get; set; }
+    }
+}

--- a/Mastonet/Entities/Status.cs
+++ b/Mastonet/Entities/Status.cs
@@ -62,6 +62,12 @@ namespace Mastonet.Entities
         public DateTime CreatedAt { get; set; }
 
         /// <summary>
+        /// An array of Emojis
+        /// </summary>
+        [JsonProperty("emojis")]
+        public IEnumerable<Emoji> Emojis { get; set; }
+
+        /// <summary>
         /// The number of replies for the status
         /// </summary>
         [JsonProperty("replies_count")]
@@ -116,12 +122,6 @@ namespace Mastonet.Entities
         public Visibility Visibility { get; set; }
 
         /// <summary>
-        /// An array of Emojis
-        /// </summary>
-        [JsonProperty("emojis")]
-        public IEnumerable<Emoji> Emojis { get; set; }
-
-        /// <summary>
         /// An array of Attachments
         /// </summary>
         [JsonProperty("media_attachments")]
@@ -140,6 +140,12 @@ namespace Mastonet.Entities
         public IEnumerable<Tag> Tags { get; set; }
 
         /// <summary>
+        /// Attached card, if any
+        /// </summary>
+        [JsonProperty("card")]
+        public Card Card { get; set; }
+
+        /// <summary>
         /// Application from which the status was posted
         /// </summary>
         [JsonProperty("application")]
@@ -151,5 +157,10 @@ namespace Mastonet.Entities
         [JsonProperty("language")]
         public string Language { get; set; }
 
+        /// <summary>
+        /// Whether the status is pinned
+        /// </summary>
+        [JsonProperty("pinned")]
+        public bool? Pinned { get; set; }
     }
 }

--- a/Mastonet/Entities/Tag.cs
+++ b/Mastonet/Entities/Tag.cs
@@ -18,5 +18,59 @@ namespace Mastonet.Entities
         /// </summary>
         [JsonProperty("url")]
         public string Url { get; set; }
+
+        /// <summary>
+        /// 7-day stats of the hashtag
+        /// </summary>
+        [JsonProperty("history")]
+        public IEnumerable<History> History { get; set; }
+    }
+
+    public class History
+    {
+        /// <summary>
+        /// UNIX time of the beginning of the day
+        /// </summary>
+        [JsonProperty("day")]
+        public int Day { get; set; }
+
+        /// <summary>
+        /// Number of statuses with the hashtag during the day
+        /// </summary>
+        [JsonProperty("uses")]
+        public int Uses { get; set; }
+
+        /// <summary>
+        /// Number of accounts that used the hashtag during the day
+        /// </summary>
+        [JsonProperty("accounts")]
+        public int Accounts { get; set; }
+    }
+
+    public class Conversation
+    {
+        /// <summary>
+        /// Conversation ID
+        /// </summary>
+        [JsonProperty("id")]
+        public long Id { get; set; }
+
+        /// <summary>
+        /// Participant accounts
+        /// </summary>
+        [JsonProperty("accounts")]
+        public IEnumerable<Account> Accounts { get; set; }
+
+        /// <summary>
+        /// Last status in the conversation
+        /// </summary>
+        [JsonProperty("last_status")]
+        public Status LastStatus { get; set; }
+
+        /// <summary>
+        /// Whether the account has read the last status
+        /// </summary>
+        [JsonProperty("unread")]
+        public bool Unread { get; set; }
     }
 }


### PR DESCRIPTION
For #39.

I'm kinda new to C# or .NET stuffs and not so confident in my code, so feel free to correct anything wrong if you found them. In particular (as far as I noticed):

- According to the [doc](https://docs.joinmastodon.org/api/entities/#meta), Attachment.meta is at least an object but its content is not strictly defined. So I put it into `JObject` and confirmed it was correctly deserialized but do you have better idea?
- File structure. I learned C# has no one-class-per-file rule like Java and I followed the structure of the doc and like put `Field` and `Source` into Account.cs. Should I still put these into separate files?

Thanks!