### PR TITLE
Let streaming stop by CancellationToken & Share a single HttpClient instance

### DIFF
--- a/API.md
+++ b/API.md
@@ -112,9 +112,9 @@ public Task AuthorizeRequest(long accountId);
 
 public Task RejectRequest(long accountId);
 
-public Task<IEnumerable<Account>> GetFollowSuggestions()
+public Task<IEnumerable<Account>> GetFollowSuggestions();
 
-public Task DeleteFollowSuggestion(long accountId)
+public Task DeleteFollowSuggestion(long accountId);
 	
 public Task<MastodonList<Status>> GetFavourites(ArrayOptions options);
 ```

--- a/Mastonet.sln
+++ b/Mastonet.sln
@@ -8,6 +8,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{AC55DEDB-D3CD-492F-96BB-575CA3B0A0F7}"
 	ProjectSection(SolutionItems) = preProject
 		API.md = API.md
+		DOC.md = DOC.md
 		oauth.png = oauth.png
 		README.md = README.md
 	EndProjectSection

--- a/Mastonet/AuthenticationClient.cs
+++ b/Mastonet/AuthenticationClient.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Net;
+using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -9,12 +10,15 @@ namespace Mastonet
 {
     public class AuthenticationClient : BaseHttpClient, IAuthenticationClient
     {
-        public AuthenticationClient(string instance)
+        public AuthenticationClient(string instance) : this(instance, DefaultHttpClient.Instance) { }
+        public AuthenticationClient(AppRegistration app) : this(app, DefaultHttpClient.Instance) { }
+
+        public AuthenticationClient(string instance, HttpClient client) : base(client)
         {
             this.Instance = instance;
         }
 
-        public AuthenticationClient(AppRegistration app)
+        public AuthenticationClient(AppRegistration app, HttpClient client) : base(client)
         {
             this.Instance = app.Instance;
             this.AppRegistration = app;

--- a/Mastonet/BaseHttpClient.cs
+++ b/Mastonet/BaseHttpClient.cs
@@ -25,7 +25,7 @@ namespace Mastonet
 
         #region Http helpers
 
-        private Task<HttpResponseMessage> SendAsync(HttpMethod method, string route, IEnumerable<KeyValuePair<string, string>> query = null, IEnumerable<KeyValuePair<string, string>> form = null, IEnumerable<MediaDefinition> media = null)
+        private async Task<HttpResponseMessage> SendAsync(HttpMethod method, string route, IEnumerable<KeyValuePair<string, string>> query = null, IEnumerable<KeyValuePair<string, string>> form = null, IEnumerable<MediaDefinition> media = null)
         {
             // Build URL
             var urlBuilder = new StringBuilder("https://").Append(Instance).Append(route);
@@ -36,43 +36,45 @@ namespace Mastonet
             var url = urlBuilder.ToString();
 
             // Build request
-            var request = new HttpRequestMessage(method, url);
-            if (media?.Any() == true)
+            using (var request = new HttpRequestMessage(method, url))
             {
-                var content = new MultipartFormDataContent();
-                foreach (var m in media)
+                if (media?.Any() == true)
                 {
-                    content.Add(new StreamContent(m.Media), m.ParamName, m.FileName);
-                }
-                if (form?.Any() == true)
-                {
-                    foreach (var pair in form)
+                    var content = new MultipartFormDataContent();
+                    foreach (var m in media)
                     {
-                        content.Add(new StringContent(pair.Value), pair.Key);
+                        content.Add(new StreamContent(m.Media), m.ParamName, m.FileName);
                     }
+                    if (form?.Any() == true)
+                    {
+                        foreach (var pair in form)
+                        {
+                            content.Add(new StringContent(pair.Value), pair.Key);
+                        }
+                    }
+                    request.Content = content;
                 }
-                request.Content = content;
-            }
-            else if (form?.Any() == true)
-            {
-                request.Content = new FormUrlEncodedContent(form);
-            }
-            request.Headers.Add("Authorization", "Bearer " + AuthToken.AccessToken);
+                else if (form?.Any() == true)
+                {
+                    request.Content = new FormUrlEncodedContent(form);
+                }
+                request.Headers.Add("Authorization", "Bearer " + AuthToken.AccessToken);
 
-            // And send it
-            return client.SendAsync(request);
+                // And send it
+                return await client.SendAsync(request);
+            }
         }
 
         protected async Task<string> Delete(string route, IEnumerable<KeyValuePair<string, string>> data = null)
         {
-            var response = await SendAsync(HttpMethod.Delete, route, query: data);
-            return await response.Content.ReadAsStringAsync();
+            using (var response = await SendAsync(HttpMethod.Delete, route, query: data))
+                return await response.Content.ReadAsStringAsync();
         }
 
         protected async Task<string> Get(string route, IEnumerable<KeyValuePair<string, string>> data = null)
         {
-            var response = await SendAsync(HttpMethod.Get, route, query: data);
-            return await response.Content.ReadAsStringAsync();
+            using (var response = await SendAsync(HttpMethod.Get, route, query: data))
+                return await response.Content.ReadAsStringAsync();
         }
 
         protected async Task<T> Get<T>(string route, IEnumerable<KeyValuePair<string, string>> data = null)
@@ -85,42 +87,44 @@ namespace Mastonet
         private Regex idFinderRegex = new Regex("_id=([0-9]+)");
         protected async Task<MastodonList<T>> GetMastodonList<T>(string route, IEnumerable<KeyValuePair<string, string>> data = null)
         {
-            var response = await SendAsync(HttpMethod.Get, route, query: data);
-            var content = await response.Content.ReadAsStringAsync();
-            var result = TryDeserialize<MastodonList<T>>(content);
-
-            // Read `Link` header
-            IEnumerable<string> linkHeader;
-            if (response.Headers.TryGetValues("Link", out linkHeader))
+            using (var response = await SendAsync(HttpMethod.Get, route, query: data))
             {
-                var links = linkHeader.Single().Split(',');
-                foreach (var link in links)
-                {
-                    if (link.Contains("rel=\"next\""))
-                    {
-                        result.NextPageMaxId = long.Parse(idFinderRegex.Match(link).Groups[1].Value);
-                    }
+                var content = await response.Content.ReadAsStringAsync();
+                var result = TryDeserialize<MastodonList<T>>(content);
 
-                    if (link.Contains("rel=\"prev\""))
+                // Read `Link` header
+                IEnumerable<string> linkHeader;
+                if (response.Headers.TryGetValues("Link", out linkHeader))
+                {
+                    var links = linkHeader.Single().Split(',');
+                    foreach (var link in links)
                     {
-                        result.PreviousPageSinceId = long.Parse(idFinderRegex.Match(link).Groups[1].Value);
+                        if (link.Contains("rel=\"next\""))
+                        {
+                            result.NextPageMaxId = long.Parse(idFinderRegex.Match(link).Groups[1].Value);
+                        }
+
+                        if (link.Contains("rel=\"prev\""))
+                        {
+                            result.PreviousPageSinceId = long.Parse(idFinderRegex.Match(link).Groups[1].Value);
+                        }
                     }
                 }
-            }
 
-            return result;
+                return result;
+            }
         }
 
         protected async Task<string> Post(string route, IEnumerable<KeyValuePair<string, string>> data = null)
         {
-            var response = await SendAsync(HttpMethod.Post, route, form: data);
-            return await response.Content.ReadAsStringAsync();
+            using (var response = await SendAsync(HttpMethod.Post, route, form: data))
+                return await response.Content.ReadAsStringAsync();
         }
 
         protected async Task<string> PostMedia(string route, IEnumerable<KeyValuePair<string, string>> data = null, IEnumerable<MediaDefinition> media = null)
         {
-            var response = await SendAsync(HttpMethod.Post, route, form: data, media: media);
-            return await response.Content.ReadAsStringAsync();
+            using (var response = await SendAsync(HttpMethod.Post, route, form: data, media: media))
+                return await response.Content.ReadAsStringAsync();
         }
 
         protected async Task<T> Post<T>(string route, IEnumerable<KeyValuePair<string, string>> data = null, IEnumerable<MediaDefinition> media = null)
@@ -132,8 +136,8 @@ namespace Mastonet
 
         protected async Task<string> Put(string route, IEnumerable<KeyValuePair<string, string>> data = null)
         {
-            var response = await SendAsync(HttpMethod.Put, route, form: data);
-            return await response.Content.ReadAsStringAsync();
+            using (var response = await SendAsync(HttpMethod.Put, route, form: data))
+                return await response.Content.ReadAsStringAsync();
         }
 
         protected async Task<T> Put<T>(string route, IEnumerable<KeyValuePair<string, string>> data = null)
@@ -143,14 +147,14 @@ namespace Mastonet
 
         protected async Task<string> Patch(string route, IEnumerable<KeyValuePair<string, string>> data = null)
         {
-            var response = await SendAsync(new HttpMethod("PATCH"), route, form: data);
-            return await response.Content.ReadAsStringAsync();
+            using (var response = await SendAsync(new HttpMethod("PATCH"), route, form: data))
+                return await response.Content.ReadAsStringAsync();
         }
 
         protected async Task<string> PatchMedia(string route, IEnumerable<KeyValuePair<string, string>> data = null, IEnumerable<MediaDefinition> media = null)
         {
-            var response = await SendAsync(new HttpMethod("PATCH"), route, form: data, media: media);
-            return await response.Content.ReadAsStringAsync();
+            using (var response = await SendAsync(new HttpMethod("PATCH"), route, form: data, media: media))
+                return await response.Content.ReadAsStringAsync();
         }
 
         protected async Task<T> Patch<T>(string route, IEnumerable<KeyValuePair<string, string>> data = null, IEnumerable<MediaDefinition> media = null)

--- a/Mastonet/BaseHttpClient.cs
+++ b/Mastonet/BaseHttpClient.cs
@@ -58,7 +58,10 @@ namespace Mastonet
                 {
                     request.Content = new FormUrlEncodedContent(form);
                 }
-                request.Headers.Add("Authorization", "Bearer " + AuthToken.AccessToken);
+                if (AuthToken != null)
+                {
+                    request.Headers.Add("Authorization", "Bearer " + AuthToken.AccessToken);
+                }
 
                 // And send it
                 return await client.SendAsync(request);

--- a/Mastonet/DefaultHttpClient.cs
+++ b/Mastonet/DefaultHttpClient.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text;
+
+namespace Mastonet
+{
+    /// <summary>
+    /// Singleton-like static class for <see cref="System.Net.Http.HttpClient"/>.
+    /// Used as default in constructor parameter of <see cref="Mastonet.BaseHttpClient"/> and its subclasses.
+    /// </summary>
+    internal static class DefaultHttpClient
+    {
+        /// <summary>
+        /// The only <see cref="System.Net.Http.HttpClient"/> instance.
+        /// </summary>
+        internal static HttpClient Instance { get; } = new HttpClient();
+    }
+}

--- a/Mastonet/MastodonClient.cs
+++ b/Mastonet/MastodonClient.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Net.Http;
 using System.Threading.Tasks;
 
 namespace Mastonet
@@ -11,7 +12,9 @@ namespace Mastonet
     {
         #region Ctor
 
-        public MastodonClient(AppRegistration appRegistration, Auth accessToken)
+        public MastodonClient(AppRegistration appRegistration, Auth accessToken) : this(appRegistration, accessToken, DefaultHttpClient.Instance) { }
+
+        public MastodonClient(AppRegistration appRegistration, Auth accessToken, HttpClient client) : base(client)
         {
             this.Instance = appRegistration.Instance;
             this.AppRegistration = appRegistration;

--- a/Mastonet/TimelineHttpStreaming.cs
+++ b/Mastonet/TimelineHttpStreaming.cs
@@ -15,8 +15,11 @@ namespace Mastonet
         private HttpClient client;
 
         public TimelineHttpStreaming(StreamingType type, string param, string instance, string accessToken)
+            : this(type, param, instance, accessToken, DefaultHttpClient.Instance) { }
+        public TimelineHttpStreaming(StreamingType type, string param, string instance, string accessToken, HttpClient client)
             : base(type, param, accessToken)
         {
+            this.client = client;
             this.instance = instance;
         }
 
@@ -50,7 +53,6 @@ namespace Mastonet
                     throw new NotImplementedException();
             }
 
-            client = new HttpClient();
             var request = new HttpRequestMessage(HttpMethod.Get, url);
             request.Headers.Add("Authorization", "Bearer " + accessToken);
             var response = await client.SendAsync(request, token);

--- a/Mastonet/TimelineStreaming.cs
+++ b/Mastonet/TimelineStreaming.cs
@@ -1,6 +1,7 @@
 ﻿using Mastonet.Entities;
 using Newtonsoft.Json;
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Mastonet
@@ -24,8 +25,7 @@ namespace Mastonet
             this.accessToken = accessToken;
         }
 
-        public abstract Task Start();
-        public abstract void Stop();
+        public abstract Task Start(CancellationToken token);
 
         protected void SendEvent(string eventName, string data)
         {

--- a/Mastonet/TimelineWebSocketStreaming.cs
+++ b/Mastonet/TimelineWebSocketStreaming.cs
@@ -10,14 +10,14 @@ using System.Threading.Tasks;
 
 namespace Mastonet
 {
-    public class TimelineWebSocketStreaming : TimelineHttpStreaming
+    public class TimelineWebSocketStreaming : TimelineStreaming
     {
         private ClientWebSocket socket;
         readonly Task<Instance> instanceGetter;
         private const int receiveChunkSize = 512;
 
         public TimelineWebSocketStreaming(StreamingType type, string param, string instance, Task<Instance> instanceGetter, string accessToken)
-            : base(type, param, instance, accessToken)
+            : base(type, param, accessToken)
         {
             this.instanceGetter = instanceGetter;
         }
@@ -26,13 +26,6 @@ namespace Mastonet
         {
             var instance = await instanceGetter;
             var url = instance?.Urls?.StreamingAPI;
-
-            if (url == null)
-            {
-                // websocket disabled, fallback to http streaming
-                await base.Start();
-                return;
-            }
 
             url += "/api/v1/streaming?access_token=" + accessToken;
 
@@ -99,8 +92,6 @@ namespace Mastonet
                 socket.Dispose();
                 socket = null;
             }
-
-            base.Stop();
         }
     }
 }


### PR DESCRIPTION
The main point of this PR is 8ce9bf0 and f02ac3d.

The first one is to stop `System.Net.WebSockets.WebSocketException (0x80004005): The 'System.Net.WebSockets.InternalClientWebSocket' instance cannot be used for communication because it has been transitioned into the 'Aborted' state.` The cause was calling CloseAsync() while ReceiveAsync() is waiting.

The second one is for saving socket resources. [This article](https://aspnetmonsters.com/2016/08/2016-08-27-httpclientwrong/) explains why.