### PR TITLE
fixed Announcement attributes to match docs

### DIFF
--- a/Mastonet/Entities/Announcement.cs
+++ b/Mastonet/Entities/Announcement.cs
@@ -22,7 +22,7 @@ public class Announcement
     /// <summary>
     /// The content of the announcement.
     /// </summary>
-    [JsonProperty("text")]
+    [JsonProperty("content")]
     public string Text { get; set; } = string.Empty;
 
     /// <summary>

--- a/Mastonet/Entities/Announcement.cs
+++ b/Mastonet/Entities/Announcement.cs
@@ -40,7 +40,7 @@ public class Announcement
     /// <summary>
     /// When the announcement was created.
     /// </summary>
-    [JsonProperty("created_at")]
+    [JsonProperty("published_at")]
     public DateTime CreatedAt { get; set; }
 
     /// <summary>


### PR DESCRIPTION
Fixes #86 

See: https://docs.joinmastodon.org/entities/Announcement/

I did not change the property names in the .NET class since that would be a breaking change.