### PR TITLE
Streaming robustness

### DIFF
--- a/Mastonet/TimelineHttpStreaming.cs
+++ b/Mastonet/TimelineHttpStreaming.cs
@@ -24,74 +24,107 @@ public class TimelineHttpStreaming : TimelineStreaming
         this.instance = instance;
     }
 
-    public override async Task Start()
+    public override async Task Start(TimeSpan? timeout = null, bool restart = true)
     {
-        string url = "https://" + instance;
-        switch (streamingType)
+        do
         {
-            case StreamingType.User:
-                url += "/api/v1/streaming/user";
-                break;
-            case StreamingType.Public:
-                url += "/api/v1/streaming/public";
-                break;
-            case StreamingType.PublicLocal:
-                url += "/api/v1/streaming/public/local";
-                break;
-            case StreamingType.Hashtag:
-                url += "/api/v1/streaming/hashtag?tag=" + param;
-                break;
-            case StreamingType.HashtagLocal:
-                url += "/api/v1/streaming/hashtag/local?tag=" + param;
-                break;
-            case StreamingType.List:
-                url += "/api/v1/streaming/list?list=" + param;
-                break;
-            case StreamingType.Direct:
-                url += "/api/v1/streaming/direct";
-                break;
-            default:
-                throw new NotImplementedException();
-        }
-
-        using (var request = new HttpRequestMessage(HttpMethod.Get, url))
-        using (cts = new CancellationTokenSource())
-        {
-            request.Headers.Add("Authorization", "Bearer " + accessToken);
-            using (var response = await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cts.Token))
+            string url = "https://" + instance;
+            switch (streamingType)
             {
-                var stream = await response.Content.ReadAsStreamAsync();
-                using (var reader = new StreamReader(stream))
+                case StreamingType.User:
+                    url += "/api/v1/streaming/user";
+                    break;
+                case StreamingType.Public:
+                    url += "/api/v1/streaming/public";
+                    break;
+                case StreamingType.PublicLocal:
+                    url += "/api/v1/streaming/public/local";
+                    break;
+                case StreamingType.Hashtag:
+                    url += "/api/v1/streaming/hashtag?tag=" + param;
+                    break;
+                case StreamingType.HashtagLocal:
+                    url += "/api/v1/streaming/hashtag/local?tag=" + param;
+                    break;
+                case StreamingType.List:
+                    url += "/api/v1/streaming/list?list=" + param;
+                    break;
+                case StreamingType.Direct:
+                    url += "/api/v1/streaming/direct";
+                    break;
+                default:
+                    throw new NotImplementedException();
+            }
+
+            try
+            {
+                using (var request = new HttpRequestMessage(HttpMethod.Get, url))
+                using (cts = new CancellationTokenSource())
                 {
-                    string? eventName = null;
-                    string? data = null;
-
-                    while (true)
+                    request.Headers.Add("Authorization", "Bearer " + accessToken);
+                    using (var response = await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cts.Token))
                     {
-                        var line = await reader.ReadLineAsync();
+                        var stream = await response.Content.ReadAsStreamAsync();
+                        using (var reader = new StreamReader(stream))
+                        {
+                            string? eventName = null;
+                            string? data = null;
 
-                        if (string.IsNullOrEmpty(line) || line.StartsWith(":"))
-                        {
-                            eventName = data = null;
-                            continue;
-                        }
-
-                        if (line.StartsWith("event: "))
-                        {
-                            eventName = line.Substring("event: ".Length).Trim();
-                        }
-                        else if (line.StartsWith("data: "))
-                        {
-                            data = line.Substring("data: ".Length);
-                            if (eventName != null)
+                            DateTime lastReceivedValidLine = DateTime.Now;
+                            while (true)
                             {
-                                SendEvent(eventName, data);
+                                var line = await reader.ReadLineAsync();
+
+                                if (string.IsNullOrEmpty(line))
+                                {
+                                    // reader returned without a line because of BaseStream.ReadTimeout
+                                    var timedOut = timeout != null && lastReceivedValidLine.Add(timeout.Value) < DateTime.Now;
+                                    if (reader.EndOfStream || timedOut)
+                                    {
+                                        // it has been too long since a valid line
+                                        var timeoutDuration = DateTime.Now.Subtract(lastReceivedValidLine);
+                                        throw new TimeoutException($"TimelineHttpStreaming timed out after: {timeoutDuration.ToString()}");
+                                    }
+                                    else
+                                    {
+                                        // nothing to do here, we haven't timed out yet
+                                        eventName = data = null;
+                                        continue;
+                                    }
+                                }
+
+                                if (line.StartsWith(":"))
+                                {
+                                    lastReceivedValidLine = DateTime.Now;
+                                    eventName = data = null;
+                                    continue;
+                                }
+
+                                if (line.StartsWith("event: "))
+                                {
+                                    lastReceivedValidLine = DateTime.Now;
+                                    eventName = line.Substring("event: ".Length).Trim();
+                                }
+                                else if (line.StartsWith("data: "))
+                                {
+                                    lastReceivedValidLine = DateTime.Now;
+                                    data = line.Substring("data: ".Length);
+                                    if (eventName != null)
+                                    {
+                                        SendEvent(eventName, data);
+                                    }
+                                }
                             }
                         }
                     }
                 }
             }
-        }
+            catch (TimeoutException)
+            {
+                if (!restart)
+                    throw;
+            }
+        } while (restart);
     }
 
     public override void Stop()

--- a/Mastonet/TimelineHttpStreaming.cs
+++ b/Mastonet/TimelineHttpStreaming.cs
@@ -123,6 +123,8 @@ public class TimelineHttpStreaming : TimelineStreaming
             {
                 if (!restart)
                     throw;
+                else
+                    NotifyStreamRestarted();
             }
         } while (restart);
     }

--- a/Mastonet/TimelineStreaming.cs
+++ b/Mastonet/TimelineStreaming.cs
@@ -24,7 +24,7 @@ public abstract class TimelineStreaming
         this.accessToken = accessToken;
     }
 
-    public abstract Task Start();
+    public abstract Task Start(TimeSpan? timeout = null, bool restart = true);
     public abstract void Stop();
 
     protected void SendEvent(string eventName, string data)

--- a/Mastonet/TimelineStreaming.cs
+++ b/Mastonet/TimelineStreaming.cs
@@ -17,6 +17,8 @@ public abstract class TimelineStreaming
     public event EventHandler<StreamFiltersChangedEventArgs>? OnFiltersChanged;
     public event EventHandler<StreamConversationEvenTargs>? OnConversation;
 
+    public event Action OnStreamRestarted;
+
     protected TimelineStreaming(StreamingType type, string? param, string? accessToken)
     {
         this.streamingType = type;
@@ -26,6 +28,14 @@ public abstract class TimelineStreaming
 
     public abstract Task Start(TimeSpan? timeout = null, bool restart = true);
     public abstract void Stop();
+
+    protected void NotifyStreamRestarted()
+    {
+        if (OnStreamRestarted != null)
+        {
+            OnStreamRestarted.Invoke();
+        }
+    }
 
     protected void SendEvent(string eventName, string data)
     {

--- a/Mastonet/TimelineWebSocketStreaming.cs
+++ b/Mastonet/TimelineWebSocketStreaming.cs
@@ -25,7 +25,7 @@ public class TimelineWebSocketStreaming : TimelineHttpStreaming
         this.instanceGetter = instanceGetter;
     }
 
-    public override async Task Start()
+    public override async Task Start(TimeSpan? timeout = null, bool restart = true)
     {
         var instance = await instanceGetter;
         var url = instance?.Urls?.StreamingAPI;
@@ -66,31 +66,54 @@ public class TimelineWebSocketStreaming : TimelineHttpStreaming
                 throw new NotImplementedException();
         }
 
-        socket = new ClientWebSocket();
-        await socket.ConnectAsync(new Uri(url), CancellationToken.None);
 
         byte[] buffer = new byte[receiveChunkSize];
         MemoryStream ms = new MemoryStream();
-        while (socket != null)
+        var lastValidMessage = DateTime.Now;
+        var timedOut = false;
+        do
         {
-            var result = await socket.ReceiveAsync(new ArraySegment<byte>(buffer), CancellationToken.None);
-
-            ms.Write(buffer, 0, result.Count);
-
-            if (result.EndOfMessage)
+            try
             {
-                var messageStr = Encoding.UTF8.GetString(ms.ToArray());
-
-                var message = JsonConvert.DeserializeObject<TimelineMessage>(messageStr);
-                if (message != null)
+                if (socket == null || socket.State != WebSocketState.Open || socket.CloseStatus != WebSocketCloseStatus.Empty)
                 {
-                    SendEvent(message.Event, message.Payload);
+                    if (socket != null) { socket.Dispose(); }
+                    socket = new ClientWebSocket();
+                    await socket.ConnectAsync(new Uri(url), CancellationToken.None);
                 }
 
-                ms.Dispose();
-                ms = new MemoryStream();
+                var result = await socket.ReceiveAsync(new ArraySegment<byte>(buffer), CancellationToken.None);
+
+                ms.Write(buffer, 0, result.Count);
+
+                if (result.EndOfMessage)
+                {
+                    var messageStr = Encoding.UTF8.GetString(ms.ToArray());
+
+                    var message = JsonConvert.DeserializeObject<TimelineMessage>(messageStr);
+                    if (message != null)
+                    {
+                        lastValidMessage = DateTime.Now;
+                        SendEvent(message.Event, message.Payload);
+                    }
+                    ms.Dispose();
+                    ms = new MemoryStream();
+                }
+
+                timedOut = timeout != null && lastValidMessage.Add(timeout.Value) < DateTime.Now;
+                if (timedOut)
+                {
+                    var timeoutDuration = DateTime.Now.Subtract(lastValidMessage);
+                    throw new TimeoutException($"TimelineWebSocketStreaming timed out after: {timeoutDuration.ToString()}");
+                }
+            } catch (TimeoutException)
+            {
+                if (!restart)
+                    throw;
             }
         }
+        while (restart);
+
         ms.Dispose();
 
         this.Stop();

--- a/Mastonet/TimelineWebSocketStreaming.cs
+++ b/Mastonet/TimelineWebSocketStreaming.cs
@@ -110,6 +110,8 @@ public class TimelineWebSocketStreaming : TimelineHttpStreaming
             {
                 if (!restart)
                     throw;
+                else
+                    NotifyStreamRestarted();
             }
         }
         while (restart);


### PR DESCRIPTION
I gave some thought to streaming robustness, and here's a proposed change that might help to improve the robustness of streaming. You can provide optional `timeout` and `restart` variables.

If `timeout` is provided, the `TimelineHttpStreaming` and `TimelineWebSocketStreaming` will count time since the last successful message (or comment) is received through the stream, and time out if it has been longer than the `timeout` provided.

If `restart` is `true` (default = `true`), then on a timeout, it will attempt to reconnect and restart the stream. If not, it'll throw the `TimeoutException` up the stack.

I've not given it a test yet - it's more of a proposal to talk through. What do you think?

Fixes: #89 