### PR TITLE
Make the properties `long`s like the mastodon schema

### DIFF
--- a/Mastonet/Entities/Account.cs
+++ b/Mastonet/Entities/Account.cs
@@ -110,19 +110,19 @@ public class Account
     /// How many statuses are attached to this account.
     /// </summary>
     [JsonProperty("statuses_count")]
-    public int StatusesCount { get; set; }
+    public long StatusesCount { get; set; }
 
     /// <summary>
     /// The reported followers of this profile.
     /// </summary>
     [JsonProperty("followers_count")]
-    public int FollowersCount { get; set; }
+    public long FollowersCount { get; set; }
 
     /// <summary>
     /// The reported follows of this profile.
     /// </summary>
     [JsonProperty("following_count")]
-    public int FollowingCount { get; set; }
+    public long FollowingCount { get; set; }
 
     // Optional attributes
 

--- a/Mastonet/Entities/Poll.cs
+++ b/Mastonet/Entities/Poll.cs
@@ -38,7 +38,7 @@ public class Poll
     /// How many votes have been received.
     /// </summary>
     [JsonProperty("votes_count")]
-    public int VotesCount { get; set; }
+    public long VotesCount { get; set; }
 
     /// <summary>
     /// How many unique accounts have voted on a multiple-choice poll.

--- a/Mastonet/Entities/Status.cs
+++ b/Mastonet/Entities/Status.cs
@@ -100,19 +100,19 @@ public class Status
     /// How many boosts this status has received.
     /// </summary>
     [JsonProperty("reblogs_count")]
-    public int ReblogCount { get; set; }
+    public long ReblogCount { get; set; }
 
     /// <summary>
     /// How many favourites this status has received.
     /// </summary>
     [JsonProperty("favourites_count")]
-    public int FavouritesCount { get; set; }
+    public long FavouritesCount { get; set; }
 
     /// <summary>
     /// How many replies this status has received.
     /// </summary>
     [JsonProperty("replies_count")]
-    public int RepliesCount { get; set; }
+    public long RepliesCount { get; set; }
 
 
     // Nullable attributes


### PR DESCRIPTION
The mastodon schema defines these items as bigints in PostgreSQL and while it is unlikely that anyone actually has billions of statuses, followers, etc., at least one account claims to have 97B followers: https://mastodon.adtension.com/@admin

It'll fail to deserialize if it hits a long that it can't fit into an int