### PR TITLE
Gracefully handle remote WebSocket disconnections.

### DIFF
--- a/Mastonet.Entities/Mastonet.Entities.csproj
+++ b/Mastonet.Entities/Mastonet.Entities.csproj
@@ -24,11 +24,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Text.Json" Version="8.0.0" />
+        <PackageReference Include="System.Text.Json" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300" PrivateAssets="All" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Mastonet/Mastonet.csproj
+++ b/Mastonet/Mastonet.csproj
@@ -24,11 +24,11 @@
 	</PropertyGroup>
 	
 	<ItemGroup>
-		<PackageReference Include="System.Text.Json" Version="8.0.0" />		
+		<PackageReference Include="System.Text.Json" Version="10.0.8" />		
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300" PrivateAssets="All" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Mastonet/TimelineHttpStreaming.cs
+++ b/Mastonet/TimelineHttpStreaming.cs
@@ -15,6 +15,8 @@ public class TimelineHttpStreaming : TimelineStreaming
     private HttpClient client;
     private CancellationTokenSource? cts;
 
+    public event EventHandler StreamingStopped;
+
     public TimelineHttpStreaming(StreamingType type, string? param, string instance, string? accessToken)
         : this(type, param, instance, accessToken, DefaultHttpClient.Instance) { }
     public TimelineHttpStreaming(StreamingType type, string? param, string instance, string? accessToken, HttpClient client)
@@ -100,6 +102,7 @@ public class TimelineHttpStreaming : TimelineStreaming
         {
             cts.Cancel();
             cts = null;
+            StreamingStopped?.Invoke(this, EventArgs.Empty);
         }
     }
 }

--- a/Mastonet/TimelineStreaming.cs
+++ b/Mastonet/TimelineStreaming.cs
@@ -27,6 +27,8 @@ public abstract class TimelineStreaming
     public abstract Task Start();
     public abstract void Stop();
 
+    public bool ReconnectStreamOnDisconnect { get; set; }
+
     protected void SendEvent(string eventName, string data)
     {
         switch (eventName)

--- a/Mastonet/TimelineWebSocketStreaming.cs
+++ b/Mastonet/TimelineWebSocketStreaming.cs
@@ -124,7 +124,7 @@ var message = JsonSerializer.Deserialize<TimelineMessage>(messageStr);
 
     public override void Stop()
     {
-        if (socket != null)
+        if (socket?.State == WebSocketState.Open)
         {
             socket.CloseAsync(WebSocketCloseStatus.NormalClosure, string.Empty, CancellationToken.None);
             socket.Dispose();


### PR DESCRIPTION
Adds a boolean property to the `TimelineStreaming` class to specify reconnection of a stream if disconnected. This is used with a new try/catch block to gracefully handle a `WebSocketException` and either stop the stream or attempt a reconnect.

I have been working on an application that uses this library and uses the Web Socket streaming. I found after ~2 hours my remote server would unexpectedly close the connection resulting in a crash. I've solved this myself adding this try/catch to catch the websocket exception and either gracefully close the stream or reconnect depending on a flag.

I'm open to other thoughts on how to handle this, and I'm not sure I love the property on the abstract class, but wanted to keep it simple so that, if there's a solution that works better for the project, it would be easy to change. Let me know what you think.