### PR TITLE
Update History.cs

### DIFF
--- a/Mastonet.Entities/History.cs
+++ b/Mastonet.Entities/History.cs
@@ -11,17 +11,17 @@ public class History
     /// UNIX timestamp on midnight of the given day.
     /// </summary>
     [JsonPropertyName("day")]
-    public int Day { get; set; }
+    public string Day { get; set; }
 
     /// <summary>
     /// the counted usage of the tag within that day.
     /// </summary>
     [JsonPropertyName("uses")]
-    public int Uses { get; set; }
+    public string Uses { get; set; }
 
     /// <summary>
     /// the total of accounts using the tag within that day.
     /// </summary>
     [JsonPropertyName("accounts")]
-    public int Accounts { get; set; }
+    public string Accounts { get; set; }
 }


### PR DESCRIPTION
Fix de-serialization format in some cases, align to the spec (see. https://docs.joinmastodon.org/entities/Tag/#history).

```
The JSON value could not be converted to System.Int32. Path: $[0].history[0].day | LineNumber: 0 | BytePositionInLine: 98.
Cannot get the value of a token type 'String' as a number.
```